### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # bundle loader for webpack
 
+## Installation
+
+`npm install --save bundle-loader`
+
 ## Usage
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)


### PR DESCRIPTION
I didn't realize at first I had to manually install it. I was thinking that bundle-loader was part of webpack already installed modules... I finally found out, on npm website, that this package could be installed. For avoid similar misunderstood, I think it's better to provide the npm command line. Regards
