### PR TITLE
fix(getOptions): deprecation warn in loaderUtils

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var loaderUtils = require("loader-utils");
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	this.cacheable && this.cacheable();
-	var query = loaderUtils.parseQuery(this.query);
+	var query = loaderUtils.getOptions(this) || {};
 	if(query.name) {
 		var options = {
 			context: query.context || this.options.context,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "bundle loader module for webpack",
   "dependencies": {
-    "loader-utils": "0.2.x"
+    "loader-utils": "^1.0.2"
   },
   "licenses": [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Summary**

- loader-utils change is throwing a DeprecationWarning in pretty much any loader on the planet.

`loaderUtils.parseQuery` is now `loderUtils.getOptions`

**Does this PR introduce a breaking change?**

No
