### PR TITLE
Add support for the require.ensure error callback added in webpack 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.5.5",
   "author": "Tobias Koppers @sokra",
   "description": "bundle loader module for webpack",
+  "peerDependencies": {
+    "webpack": "^2.4.0"
+  },
   "dependencies": {
     "loader-utils": "^1.0.2"
   },


### PR DESCRIPTION
Adds support for an optional error callback to the bundle-loader.

This work was originally done by @richardscarrott: https://github.com/richardscarrott/require-error-handler-webpack-plugin/blob/master/src/BundleLoader.js.

This PR uses the version created by @richardscarrott with refactoring to reflect changes from the bundle-loader repo since the fork was created.

