### PR TITLE
Prevent chunking out when not in production environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports.pitch = function(remainingRequest) {
 		var chunkNameParam = '';
 	}
 	var result;
-	if(query.lazy) {
+	if(process.env.NODE_ENV !== 'production') {
+		result = ["var file = require(", loaderUtils.stringifyRequest(this, "!!" + remainingRequest), "); module.exports = function(cb) { cb(file); }"];
+	} else if(query.lazy) {
 		result = [
 			"module.exports = function(cb) {\n",
 			"	require.ensure([], function(require) {\n",


### PR DESCRIPTION
Due to HMR problems with on-demand chunks, I figured it would be nice if the loader loaded the chunks synchronously when in dev environment and as so far in prod. And that's what this commit does.

_Other ideas: I was also wondering about adding some additional flag to _force_ async loading in development, but eventually opted-out. Alternatively, sync loading in development could be made an optional (instead of default) behavior. If you find some of the modifications useful, I'd be happy to alter the merge request to suit more needs._