### PR TITLE
fix(package): remove outdated link to license

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
   "dependencies": {
     "loader-utils": "^1.0.2"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": 'MIT',
   "repository": {
     "type": "git",
     "url": "git://github.com/webpack/bundle-loader.git"


### PR DESCRIPTION
Use valid license value for package.json

ref: https://docs.npmjs.com/files/package.json#license