### PR TITLE
fix(index): add `rootContext` (`this.rootContext`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports.pitch = function(remainingRequest) {
 	var query = loaderUtils.getOptions(this) || {};
 	if(query.name) {
 		var options = {
-			context: query.context || this.options.context,
+			context: query.context || this.rootContext || this.options && this.options.context,
 			regExp: query.regExp
 		};
 		var chunkName = loaderUtils.interpolateName(this, query.name, options);


### PR DESCRIPTION
Webpack 4 removed `this.options` from loaders. The replacement for
`this.options.context` is `this.rootContext`.

> this.options and this.rootContext
> webpack 3 already deprecated this.options in the loader context. webpack 4 removes it now.
>
> A lot of people are missing the this.options.context value now. It has been added as this.rootContext.

https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202

Fixes #69 