### PR TITLE
Support json modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var loaderUtils = require("loader-utils");
+var LoaderDependency = require("webpack/lib/dependencies/LoaderDependency");
 
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
@@ -42,6 +43,12 @@ module.exports.pitch = function(remainingRequest) {
 			"		callbacks[i](data);\n",
 			"	}\n",
 			"}" + chunkNameParam + ");"];
+	}
+	if (this._module.type !== "javascript/auto") {
+		var nmf = this._compilation.dependencyFactories.get(LoaderDependency);
+		this._module.type = "javascript/auto";
+		this._module.generator = nmf.getGenerator("javascript/auto");
+		this._module.parser = nmf.getParser("javascript/auto");
 	}
 	return result.join("");
 }


### PR DESCRIPTION
This is a proposal for a fix to #74. It is not elegant but it gets the job done.
The way the NormalModuleFactory is found from the dependencyFactories is probably not the right way to do it, but I don't have a good enough understanding on how to do this stuff, and this is the proposal I was able to come up with:-)

The example environment that this PR is fixing is:
index.js:
```
require("bundle-loader!./test.json");
```
test.json:
```
{ "any": "json file" }
```
Without this fix, this currently returns the error:

> ERROR in ./src/test.json (./node_modules/bundle-loader!./src/test.json)
Module parse failed: Unexpected token v in JSON at position 0 while parsing near 'var cbs = [],
        data...'
You may need an appropriate loader to handle this file type.